### PR TITLE
Fix duplicate order race condition by using consistent rounding factor

### DIFF
--- a/src/Backend/Services/LnMarketsBackgroundService.cs
+++ b/src/Backend/Services/LnMarketsBackgroundService.cs
@@ -12,7 +12,6 @@ public class LnMarketsBackgroundService(IServiceScopeFactory _scopeFactory, ILog
 {
     private static class Constants
     {
-        public const decimal PriceRoundingFactor = 50m;
         public const int SatoshisPerBitcoin = 100_000_000;
         public const string JsonRpcVersion = "2.0";
         public const string SubscribeMethod = "v1/public/subscribe";
@@ -108,7 +107,7 @@ public class LnMarketsBackgroundService(IServiceScopeFactory _scopeFactory, ILog
             if (!IsMessageValid(messageAsLastPriceDTO, lastPrice, lastCall))
                 return null;
 
-            var price = Math.Floor(messageAsLastPriceDTO.LastPrice / Constants.PriceRoundingFactor) * Constants.PriceRoundingFactor;
+            var price = Math.Floor(messageAsLastPriceDTO.LastPrice / _options.Value.Factor) * _options.Value.Factor;
 
             using var scope = _scopeFactory?.CreateScope();
             if (scope == null)
@@ -141,7 +140,7 @@ public class LnMarketsBackgroundService(IServiceScopeFactory _scopeFactory, ILog
         if (messageTimeDifference >= TimeSpan.FromSeconds(_options.Value.MessageTimeoutSeconds))
             return false;
 
-        var price = Math.Floor(messageData.LastPrice / Constants.PriceRoundingFactor) * Constants.PriceRoundingFactor;
+        var price = Math.Floor(messageData.LastPrice / _options.Value.Factor) * _options.Value.Factor;
         if (price == lastPrice)
             return false;
 


### PR DESCRIPTION
  ## Problem Description

  The application was experiencing duplicate order creation due to a **rounding factor mismatch** between message
  validation and trade execution logic. This caused a race condition where multiple WebSocket price updates could
  pass validation but generate identical trade prices, leading to duplicate orders being placed.

  ## Root Cause Analysis

  The issue stemmed from **inconsistent price rounding** across different parts of the codebase:

  ### Before Fix:
  - **Message Validation** (`IsMessageValid`): Used `PriceRoundingFactor = 50m`
  - **Price Calculation** (`HandleWsTextMessage`): Used `PriceRoundingFactor = 50m`
  - **Trade Execution** (`ProcessTradeExecution`): Used `options.Factor = 1000` (default)

  This mismatch created a window where different WebSocket messages could pass validation but result in the same
  final trade price.

  ## Example Scenario

  Here's how duplicate orders occurred:

  WebSocket Message 1: LastPrice = 50,025
  ├── Validation: Math.Floor(50025 / 50) * 50 = 50,000 ✓ (passes, different from last)
  ├── Price Calc: Math.Floor(50025 / 50) * 50 = 50,000
  └── Trade Exec: Math.Floor(50025 / 1000) * 1000 = 50,000

  WebSocket Message 2: LastPrice = 50,075 (arrives ~simultaneously)
  ├── Validation: Math.Floor(50075 / 50) * 50 = 50,050 ✓ (passes, different from 50,000)
  ├── Price Calc: Math.Floor(50075 / 50) * 50 = 50,050
  └── Trade Exec: Math.Floor(50075 / 1000) * 1000 = 50,000 ← DUPLICATE!

  Both messages passed validation because they resulted in different 50m-rounded prices (`50,000` vs `50,050`), but
   both created orders at the same 1000-rounded price (`50,000`).

  ## Solution

  **Use consistent rounding factor throughout the entire pipeline:**

  ### Changes Made:
  1. **Removed** unused `PriceRoundingFactor = 50m` constant
  2. **Updated** `IsMessageValid()` to use `_options.Value.Factor`
  3. **Updated** `HandleWsTextMessage()` price calculation to use `_options.Value.Factor`
  4. **Maintained** existing `ProcessTradeExecution()` usage of `options.Factor`

  ### After Fix:
  ```csharp
  // All three locations now use the same factor (default: 1000)
  var price = Math.Floor(lastPrice / _options.Value.Factor) * _options.Value.Factor;
  ```

  Why the Rounding Factor Matters

  The rounding factor serves multiple purposes:

  1. Price Discretization: Rounds prices to meaningful increments (e.g., $1000 intervals)
  2. Duplicate Prevention: Ensures only significant price movements trigger new orders
  3. Market Efficiency: Avoids excessive micro-adjustments to trading positions

  When different parts of the system use different rounding factors, the duplicate prevention mechanism breaks down
   because:

  - Fine-grained validation (50m factor) allows through many price variations
  - Coarse-grained execution (1000 factor) collapses these variations into identical orders
  - Race conditions occur when multiple fine-grained prices map to the same coarse-grained price

  Impact

  - Eliminates duplicate order race conditions
  - Maintains all existing trading functionality
  - Simplifies codebase by removing unused constants
  - Improves system reliability and trading accuracy

  Files Changed

  - src/Backend/Services/LnMarketsBackgroundService.cs
    - Removed PriceRoundingFactor constant
    - Updated IsMessageValid() method
    - Updated HandleWsTextMessage() method